### PR TITLE
Add optional download numpy using [interface]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ It returns a list of values that correspond to the limits of the classes (starti
 
 
 
-This package also support a `JenksNaturalBreaks` (require `NumPy`) class as interface (inspired by `scikit-learn` classes). The `.fit` and `.group` behavior is slightly different from `jenks_breaks`, by accepting value outside the range of the minimum and maximum value of `breaks_`, retaining the input size. It means that fit and group will use only the `inner_bound_`. All value below the min bound will be included in the first group and all value higher than the max bound will be included in the last group.
+This package also support a `JenksNaturalBreaks` (require `NumPy`) class as interface (inspired by `scikit-learn` classes). The `.fit` and `.group` behavior is slightly different from `jenks_breaks`, by accepting value outside the range of the minimum and maximum value of `breaks_`, retaining the input size. It means that fit and group will use only the `inner_bound_`. All value below the min bound will be included in the first group and all value higher than the max bound will be included in the last group. Install using `pip install jenkspy[interface]` to automatically include `NumPy`.
 
 
 
@@ -91,6 +91,12 @@ Installation
 
     pip install jenkspy
 
+
++ **To include numpy in pypi**
+
+.. code:: shell
+
+    pip install jenkspy[interface]
 
 + **From source**
 

--- a/setup.py
+++ b/setup.py
@@ -52,4 +52,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Topic :: Scientific/Engineering",
         ],
+    extras_require={
+        'interface': ['numpy']
+    }
     )


### PR DESCRIPTION
Because I'm still too lazy to remove numpy dependency, lets just have numpy optional install using `pip install jenkspy[interface]`.

Haven't tested, since I don't know how to test the optional pip install (can't install locally since I can't build cython).

You might need to add `python3 install jenkspy[interface]` in appveyor to include this to the test.